### PR TITLE
FIX: cannot use pyinfra with coolify fetched inventory

### DIFF
--- a/infraninja/inventory/coolify.py
+++ b/infraninja/inventory/coolify.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import sys
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -89,6 +90,9 @@ class Coolify:
 
         # Load initial configuration
         self.load_servers()
+
+        # Generate and update SSH configuration
+        self.refresh_ssh_config()
 
     def _make_api_request(
         self, endpoint: str, method: str = "GET", data: Optional[Dict] = None
@@ -231,11 +235,13 @@ class Coolify:
                         f"Skipping server {server_name} as it is not reachable or usable"
                     )
                     continue
-            
+
             # Skip localhost entries
-            if server_name.lower() == "localhost" or \
-               ip_address == "127.0.0.1" or \
-               ip_address == "::1":
+            if (
+                server_name.lower() == "localhost"
+                or ip_address == "127.0.0.1"
+                or ip_address == "::1"
+            ):
                 continue
 
             # Create server entry for PyInfra
@@ -256,13 +262,102 @@ class Coolify:
             )
         return result
 
-    def get_servers(self) -> List[Tuple[str, Dict[str, Any]]]:
-        """Get the list of servers.
+    def generate_ssh_config(self) -> str:
+        """Generate SSH configuration based on the servers list.
 
         Returns:
-            List[Tuple[str, Dict[str, Any]]]: List of (hostname, attributes) tuples
+            str: SSH configuration content
         """
-        return self.servers
+        config_content = "# Coolify SSH Config - Auto-generated\n\n"
+
+        for server_name, attributes in self.servers:
+            hostname = attributes.get("hostname")
+            ssh_user = attributes.get("ssh_user")
+            ssh_port = attributes.get("ssh_port", 22)
+
+            if hostname and ssh_user:
+                config_content += f"Host {server_name}\n"
+                config_content += f"    HostName {hostname}\n"
+                config_content += f"    User {ssh_user}\n"
+                config_content += f"    Port {ssh_port}\n"
+                config_content += f"    IdentityFile {self.ssh_key_path}\n"
+
+        return config_content
+
+    def save_ssh_config(self, config_content: str) -> None:
+        """Save SSH configuration to a file.
+
+        Args:
+            config_content: SSH configuration content to save
+
+        Raises:
+            CoolifySSHError: If saving the config fails
+        """
+        try:
+            ssh_config_file = self.ssh_config_dir / "coolify.conf"
+
+            # Ensure the directory exists
+            self.ssh_config_dir.mkdir(parents=True, exist_ok=True)
+
+            # Write config to file
+            with open(ssh_config_file, "w") as f:
+                f.write(config_content)
+
+            logger.info(f"SSH config saved to {ssh_config_file}")
+        except Exception as e:
+            logger.error(f"Failed to save SSH config: {str(e)}")
+            raise CoolifySSHError(f"Failed to save SSH config: {str(e)}")
+
+    def update_main_ssh_config(self) -> None:
+        """Update the main SSH config file to include Coolify configs.
+
+        Raises:
+            CoolifySSHError: If updating the config fails
+        """
+        try:
+            # Use a wildcard include pattern as requested
+            include_line = f"Include {self.ssh_config_dir}/*"
+
+            # Check if the main SSH config file exists
+            if not self.main_ssh_config.exists():
+                # Create the file with the include line
+                with open(self.main_ssh_config, "w") as f:
+                    f.write(f"{include_line}\n")
+
+                # Set appropriate permissions
+                os.chmod(self.main_ssh_config, 0o600)
+                logger.info("Created main SSH config file with include directive")
+                return
+
+            # Read current config
+            with open(self.main_ssh_config, "r") as f:
+                config_content = f.read()
+
+            # Check if any include directive for the config directory already exists
+            include_pattern = f"Include {self.ssh_config_dir}"
+
+            if include_pattern not in config_content:
+                # Add the include directive at the beginning
+                with open(self.main_ssh_config, "w") as f:
+                    f.write(f"{include_line}\n{config_content}")
+                logger.info("Updated main SSH config with include directive")
+            else:
+                logger.info("Include directive already exists in main SSH config")
+
+        except Exception as e:
+            logger.error(f"Failed to update main SSH config: {str(e)}")
+            raise CoolifySSHError(f"Failed to update main SSH config: {str(e)}")
+
+    def refresh_ssh_config(self) -> None:
+        """Generate and save new SSH configuration.
+
+        Raises:
+            CoolifySSHError: If saving the config fails
+        """
+        config_content = self.generate_ssh_config()
+        self.save_ssh_config(config_content)
+        self.update_main_ssh_config()
+        logger.info("SSH configuration refreshed successfully")
 
     def get_server_by_name(self, name: str) -> Optional[Dict[str, Any]]:
         """Get server details by name.
@@ -294,3 +389,11 @@ class Coolify:
             return self.servers
         finally:
             self.tags = original_tags
+
+    def get_servers(self) -> List[Tuple[str, Dict[str, Any]]]:
+        """Get the list of servers.
+
+        Returns:
+            List[Tuple[str, Dict[str, Any]]]: List of (hostname, attributes) tuples
+        """
+        return self.servers

--- a/infraninja/inventory/coolify.py
+++ b/infraninja/inventory/coolify.py
@@ -262,7 +262,7 @@ class Coolify:
             )
         return result
 
-    def generate_ssh_config(self) -> str:
+    def _generate_ssh_config(self) -> str:
         """Generate SSH configuration based on the servers list.
 
         Returns:
@@ -284,7 +284,7 @@ class Coolify:
 
         return config_content
 
-    def save_ssh_config(self, config_content: str) -> None:
+    def _save_ssh_config(self, config_content: str) -> None:
         """Save SSH configuration to a file.
 
         Args:
@@ -308,7 +308,7 @@ class Coolify:
             logger.error(f"Failed to save SSH config: {str(e)}")
             raise CoolifySSHError(f"Failed to save SSH config: {str(e)}")
 
-    def update_main_ssh_config(self) -> None:
+    def _update_main_ssh_config(self) -> None:
         """Update the main SSH config file to include Coolify configs.
 
         Raises:
@@ -354,9 +354,9 @@ class Coolify:
         Raises:
             CoolifySSHError: If saving the config fails
         """
-        config_content = self.generate_ssh_config()
-        self.save_ssh_config(config_content)
-        self.update_main_ssh_config()
+        config_content = self._generate_ssh_config()
+        self._save_ssh_config(config_content)
+        self._update_main_ssh_config()
         logger.info("SSH configuration refreshed successfully")
 
     def get_server_by_name(self, name: str) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
we cannot use pyinfra with the inventory we fetched from coolify.

right now the connection depends on the host name of the server which would be defined in an ssh config.

coolify doesnt create ssh configs by default which would allow us to connect via SSH to the server with pyinfra

attempting to fix below